### PR TITLE
Fixed Resume Indent

### DIFF
--- a/source/casual-markdown.js
+++ b/source/casual-markdown.js
@@ -89,8 +89,6 @@
           icon: []
       };
 
-      console.log(headerContent);
-
       let alignedMatch;
       alignedRegex = /(=(?:-|\^|\+|_)=) ([^\n]*)(?:\n|$)/g;
 
@@ -175,6 +173,11 @@
 
   //===== parse markdown string into HTML content (cater code-block)
   md.html = function (mdText) { 
+    // if the entire resume is in an indent, remove it so markdown can be parsed correctly
+    const indent = mdText.match(/^\n{0,}(\s{2,})#/)
+    // count the number of spaces in indent$1
+    const indentLength = indent ? indent[1].length + 1: 0
+
     // replace \r\n to \n, and handle front matter for simple YAML
     mdText = mdText.replace(/\r\n/g, '\n').replace( /^---+\s*\n([\s\S]*?)\n---+\s*\n/, md.formatYAML )
     // handle code-block.


### PR DESCRIPTION
Resume can now be entirely indented for nice html syntax
Also removed console.log statement